### PR TITLE
added route to display if user manages a location

### DIFF
--- a/backend/api/location/config/routes.json
+++ b/backend/api/location/config/routes.json
@@ -9,6 +9,14 @@
     },
     {
       "method": "GET",
+      "path": "/locations/admin",
+      "handler": "location.isAdmin",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
       "path": "/locations/count",
       "handler": "location.count",
       "config": {

--- a/backend/api/location/controllers/location.js
+++ b/backend/api/location/controllers/location.js
@@ -5,4 +5,15 @@
  * to customize this controller
  */
 
-module.exports = {};
+module.exports = {
+  async isAdmin(ctx) {
+    let locations;
+    locations = await strapi.query('location').find({
+      admins: ctx.state.user.id
+    });
+    return {
+      "managedLocations": locations.map(loc => loc.id)
+    };
+  },
+
+};

--- a/backend/api/location/documentation/1.0.0/location.json
+++ b/backend/api/location/documentation/1.0.0/location.json
@@ -254,6 +254,63 @@
         }
       }
     },
+    "/locations/admin": {
+      "get": {
+        "deprecated": false,
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "foo": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "summary": "",
+        "tags": [
+          "Location"
+        ],
+        "parameters": []
+      }
+    },
     "/locations/count": {
       "get": {
         "deprecated": false,

--- a/backend/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "03/16/2020 4:54:13 PM"
+    "x-generation-date": "03/17/2020 2:50:13 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -1707,6 +1707,63 @@
             }
           }
         }
+      }
+    },
+    "/locations/admin": {
+      "get": {
+        "deprecated": false,
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "foo": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "summary": "",
+        "tags": [
+          "Location"
+        ],
+        "parameters": []
       }
     },
     "/locations/count": {


### PR DESCRIPTION
## Story Number and GitHub Issue

* 

## Description of Change

-Added new route "/locations/admin" 

That will check if the logged in user manages any locations, returning an array of those locations they manage. 

* 

## Any Screenshot/GIFs of UI Changes and/or Bug Fixes

* 

## If Applicable, Any User Mentions Responsible For Reviewing The Changes

* 

## PR Checklist
- [ ] Ran Code Linting 
- [ ] Ran Unit Tests and All Pass
- [ ] Any New Functional Changes Have Unit Tests Added to Them
- [ ] Both Frontend and Backend Apps Compile Successfully and Can Start Up With No Issue


## :warning: **After Merging** :warning:
* Delete the branch on GitHub
* For any bug fixes, make sure code works in master and fixes original issue
* For any documentation merges, run `mkdocs gh-deploy` locally from an updated master branch